### PR TITLE
Set correct path for services

### DIFF
--- a/acmeair-as/Dockerfile
+++ b/acmeair-as/Dockerfile
@@ -12,7 +12,7 @@ ADD ./build/libs/*.war /opt/ibm/wlp/usr/servers/defaultServer/apps
 
 EXPOSE 80
 
-ENV CUSTOMER_SERVICE=nginx1/acmeair
+ENV CUSTOMER_SERVICE=customer_service_liberty1/acmeair-cs
 ENV MONGO_HOST=session_db1
 ENV MONGO_DBNAME=acmeair_sessiondb
 

--- a/acmeair-bs/Dockerfile
+++ b/acmeair-bs/Dockerfile
@@ -12,7 +12,7 @@ ADD ./build/libs/*.war /opt/ibm/wlp/usr/servers/defaultServer/apps
 
 EXPOSE 80
 
-ENV AUTH_SERVICE=nginx1/acmeair
+ENV AUTH_SERVICE=auth_service_liberty1/acmeair-as
 ENV MONGO_HOST=booking_db1
 ENV MONGO_DBNAME=acmeair_bookingdb
 

--- a/acmeair-cs/Dockerfile
+++ b/acmeair-cs/Dockerfile
@@ -12,7 +12,7 @@ ADD ./build/libs/*.war /opt/ibm/wlp/usr/servers/defaultServer/apps
 
 EXPOSE 80
 
-ENV AUTH_SERVICE=nginx1/acmeair
+ENV AUTH_SERVICE=auth_service_liberty1/acmeair-as
 ENV MONGO_HOST=customer_db1
 ENV MONGO_DBNAME=acmeair_customerdb
 


### PR DESCRIPTION
Currently, each service will attempt to send requests through nginx when communicating with other services on a wrong location. This will fail as the routing for these services will attempt to request the services via nginx, for example: nginx1/acmeair/rest/api/customer/validateid (results in HTTP 404) instead of customer_service_liberty1/acmeair-cs/rest/api/customer/validateid.

Note: I see that it could be possible to route requests through nginx, but this would only be beneficial if it acted as a load balancer all services altogether. I can amend a changes that use this behavior if the maintainers of this repo wants that instead of services talking to each other directly.