### PR TITLE
Expose configuration through envvars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,117 @@ build/
 .classpath
 .project
 .gradle
+.idea
 .DS_Store
 target
+
+# Created by https://www.toptal.com/developers/gitignore/api/intellij
+# Edit at https://www.toptal.com/developers/gitignore?templates=intellij
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+*.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+.idea/$CACHE_FILE$
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+.idea/codestream.xml
+
+# End of https://www.toptal.com/developers/gitignore/api/intellij

--- a/acmeair-monolithic-java.yaml
+++ b/acmeair-monolithic-java.yaml
@@ -17,10 +17,8 @@ spec:
     spec:
       containers:
       - name: acmeair-java
-        #image: IMAGE_NAME
-        #imagePullPolicy: Always
-        image: acmeair-test
-        imagePullPolicy: Never
+        image: IMAGE_NAME
+        imagePullPolicy: Always
         env:
         - name: WLP_LOGGING_CONSOLE_FORMAT
           value: "dev"

--- a/acmeair-monolithic-java.yaml
+++ b/acmeair-monolithic-java.yaml
@@ -1,10 +1,14 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: acmeair-monolithic-java-deployment
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: acmeair
+      tier: monolithic
   template:
     metadata:
       labels:
@@ -13,21 +17,46 @@ spec:
     spec:
       containers:
       - name: acmeair-java
-        image: IMAGE_NAME
-        imagePullPolicy: Always
+        #image: IMAGE_NAME
+        #imagePullPolicy: Always
+        image: acmeair-test
+        imagePullPolicy: Never
         env:
+        - name: WLP_LOGGING_CONSOLE_FORMAT
+          value: "dev"
+        - name: WLP_LOGGING_CONSOLE_LOGLEVEL
+          value: "info"
+        - name: WLP_LOGGING_CONSOLE_SOURCE
+          value: "message,trace,accessLog,ffdc,audit"
         - name: MONGO_MANUAL
           value: "true"
         - name: MONGO_HOST
-          value: "localhost"
+          #value: "localhost"
+          # for kubernetes deployment
+          value: "acmeair-db"
         - name: MONGO_PORT
           value: "27017"
+          # comment user:pass if using a default mongo deployment
         - name: MONGO_DBNAME
           value: "acmeair"
-        - name: MONGO_USER
-          value: "user"
-        - name: MONGO_PASSWORD
-          value: "password"
+        #- name: MONGO_USER
+        #  value: "user"
+        #- name: MONGO_PASSWORD
+        #  value: "password"
+        - name: MONGO_MAX_CONNECTIONS
+          value: "100" # default
+        - name: MONGO_MIN_CONNECTIONS
+          value: "10"  # default
+        - name: MONGO_CONNECTION_TIMEOUT
+          value: "10"  # default
+        - name: CORE_THREADS
+          value: "-1"  # default
+        - name: MAX_THREADS
+          value: "-1"  # default
+        - name: PERSIST_TIMEOUT # Amount of time that a socket will be allowed to remain idle between requests.
+          value: "30"  # default
+        - name: MAX_KEEP_ALIVE_REQUESTS
+          value: "-1" # default
         resources:
           requests:
             cpu: "700m"
@@ -40,9 +69,10 @@ metadata:
     app: acmeair
     tier: monolithic
 spec:
+  type: NodePort
   ports:
   - protocol: TCP
-    port: 80
+    port: 9080
     name: http
   selector:
     app: acmeair
@@ -79,7 +109,7 @@ spec:
 status:
   loadBalancer: {}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -87,6 +117,9 @@ metadata:
 spec:
   replicas: 1
   strategy: {}
+  selector:
+    matchLabels:
+      service: acmeair-db
   template:
     metadata:
       creationTimestamp: null
@@ -96,6 +129,11 @@ spec:
       containers:
       - image: mongo
         name: acmeair-db
+          #env:
+          #- name: MONGO_INITDB_ROOT_USERNAME
+          #  value: "user"
+          #- name: MONGO_INITDB_ROOT_PASSWORD
+          #  value: "password"
         ports:
         - containerPort: 27017
           protocol: TCP

--- a/src/main/java/com/acmeair/mongo/ConnectionManager.java
+++ b/src/main/java/com/acmeair/mongo/ConnectionManager.java
@@ -4,13 +4,18 @@ import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 
+import com.mongodb.connection.ConnectionPoolSettings;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 
+import com.acmeair.mongo.MongoConstants;
 import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoClientURI;
 import com.mongodb.MongoCredential;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoClientOptions.Builder;
 import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoDatabase;
 
@@ -41,9 +46,27 @@ public class ConnectionManager implements MongoConstants {
 		String hostname = "localhost";
 		int port = 27017;
 		String dbname = "acmeair";
+		int maxConnections = 100;	// default is 100
+		int minConnections = 10; 	// default is 10
+		int connectionTimeout = 10;	// default is 10
 
 		String mongoManual = System.getenv("MONGO_MANUAL");
 		Boolean isManual = Boolean.parseBoolean(mongoManual);
+
+		String mongoMaxConnectionsPerHost = System.getenv("MONGO_MAX_CONNECTIONS");
+		if (mongoMaxConnectionsPerHost != null) {
+			maxConnections = Integer.parseInt(mongoMaxConnectionsPerHost);
+		}
+
+		String mongoMinConnectionsPerHost = System.getenv("MONGO_MIN_CONNECTIONS");
+		if (mongoMinConnectionsPerHost != null) {
+			minConnections = Integer.parseInt(mongoMinConnectionsPerHost);
+		}
+
+		String mongoConnectionTimeout = System.getenv("MONGO_CONNECTION_TIMEOUT");
+		if (mongoConnectionTimeout != null) {
+			connectionTimeout = Integer.parseInt(mongoConnectionTimeout);
+		}
 
 		String mongoHost = System.getenv("MONGO_HOST");
 		if (mongoHost != null) {
@@ -63,6 +86,13 @@ public class ConnectionManager implements MongoConstants {
 		String mongoUser = System.getenv("MONGO_USER");
 
 		String mongoPassword = System.getenv("MONGO_PASSWORD");
+		MongoClientOptions.Builder clientOptions = new MongoClientOptions.Builder();
+		clientOptions.connectionsPerHost(maxConnections)
+				.minConnectionsPerHost(minConnections)
+				.connectTimeout(connectionTimeout);
+
+		MongoClientOptions options = clientOptions.build();
+
 		try {
 
 			// If MONGO_MANUAL is set to true, it will set up the DB connection
@@ -71,9 +101,9 @@ public class ConnectionManager implements MongoConstants {
 				if (mongoUser != null) {
 					MongoCredential credential = MongoCredential.createCredential(mongoUser, dbname,
 							mongoPassword.toCharArray());
-					mongoClient = new MongoClient(new ServerAddress(hostname, port),Arrays.asList(credential));
+					mongoClient = new MongoClient(new ServerAddress(hostname, port),Arrays.asList(credential),options);
 				}else {
-					mongoClient = new MongoClient(hostname, port);
+					mongoClient = new MongoClient(new ServerAddress(hostname, port), options);
 				}
 			} else {
 				// Check if VCAP_SERVICES exist, and if it does, look up the url
@@ -95,12 +125,12 @@ public class ConnectionManager implements MongoConstants {
 					JSONObject credentials = (JSONObject) mongoService.get("credentials");
 					String url = (String) credentials.get("url");
 					logger.fine("service url = " + url);
-					MongoClientURI mongoURI = new MongoClientURI(url);
+					MongoClientURI mongoURI = new MongoClientURI(url, clientOptions);
 					mongoClient = new MongoClient(mongoURI);
 					dbname = mongoURI.getDatabase();
 
 				}else {
-					mongoClient = new MongoClient(hostname, port);
+					mongoClient = new MongoClient(new ServerAddress(hostname, port), options);
 				}
 			}
 			logger.fine("#### Mongo DB Database Name " + dbname + " ####");
@@ -108,6 +138,9 @@ public class ConnectionManager implements MongoConstants {
 			logger.info("#### Mongo DB Server " + mongoClient.getAddress().getHost() + " ####");
 			logger.info("#### Mongo DB Port " + mongoClient.getAddress().getPort() + " ####");
 			logger.info("#### Mongo DB is created with DB name " + dbname + " ####");
+			logger.info("#### Mongo Max Conn " + maxConnections + " ####");
+			logger.info("### Mongo Configuration:");
+			logger.info(options.toString());
 		} catch (Exception e) {
 			logger.severe("Caught Exception : " + e.getMessage());
 		}

--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -4,7 +4,11 @@
     <featureManager>
          <feature>cdi-2.0</feature>
          <feature>jaxrs-2.1</feature>
+         <feature>mpMetrics-2.0</feature>
+         <feature>monitor-1.0</feature>
     </featureManager>
+
+    <mpMetrics authentication="false"/>
 
     <!-- To access this server from a remote client add a host attribute to the following element, e.g. host="*" -->
     <httpEndpoint id="defaultHttpEndpoint"
@@ -12,5 +16,27 @@
                   httpPort="9080"
                   httpsPort="9443" />
 
+    <!-- Reuse cookies accross multiple replicas -->
+    <remoteIp proxies="" useRemoteIpInAccessLog="false"/>
+
+    <variable name="CORE_THREADS" defaultValue="-1"/>
+    <variable name="MAX_THREADS" defaultValue="-1"/>
+    <executor
+            name="LargeThreadPool"
+            id="default"
+            coreThreads="${CORE_THREADS}"
+            maxThreads="${MAX_THREADS}"
+            keepAlive="60s"
+            stealPolicy="LOCAL"
+            rejectedWorkPolicy="CALLER_RUNS"/>
+
+    <variable name="PERSIST_TIMEOUT" defaultValue="30"/>
+    <variable name="MAX_KEEP_ALIVE_REQUESTS" defaultValue="-1"/>
+    <httpOptions
+            persistTimeout="${PERSIST_TIMEOUT}"
+            maxKeepAliveRequests="${MAX_KEEP_ALIVE_REQUESTS}"/>
+
     <webApplication name="acmeair-monolithic" location="acmeair-java-2.0.0-SNAPSHOT.war" contextRoot="/"/>
 </server>
+
+


### PR DESCRIPTION
Pull request to facilitate how to configure AcmeAir @ Kubernetes using ConfigMaps

1. Add `minConnections`, `maxConnections`, and `connectionTimeout` variables to configure MongoDB using envvar
2. Expose `executor.coreThreads`, `executor.maxThreads`, `httpOptions.persistTimeout`, `httpOptions.maxKeepAliveRequests` through envvars to configura OpenLiberty
3. Update K8s deployment apiVersion